### PR TITLE
Add batch size configuration to Meltano and Iceberg sink

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -34,6 +34,7 @@ plugins:
     - name: s3_endpoint
     - name: oauth2_server_uri
     - name: scope
+    - name: batch_size
 
     settings_group_validation:
     - [catalog_type,warehouse,namespace]

--- a/target_iceberg/sinks.py
+++ b/target_iceberg/sinks.py
@@ -19,13 +19,11 @@ formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(messag
 handler.setFormatter(formatter)
 logger.addHandler(handler)
 
-BATCH_SIZE = 10000
+DEFAULT_BATCH_SIZE = 10000
 
 
 class IcebergSink(BatchSink):
     """Iceberg target sink class."""
-
-    batch_max_size = BATCH_SIZE
 
     def __init__(
         self,
@@ -35,6 +33,7 @@ class IcebergSink(BatchSink):
         key_properties: list[str] | None,
     ) -> None:
         super().__init__(target, stream_name, schema, key_properties)
+        self.batch_max_size = self.config.get("batch_size", DEFAULT_BATCH_SIZE)
 
     def process_batch(self, context: dict) -> None:
         """Write out any prepped records and return once fully written.

--- a/target_iceberg/target.py
+++ b/target_iceberg/target.py
@@ -7,8 +7,8 @@ from singer_sdk.target_base import Target
 
 from target_iceberg.sinks import (
     IcebergSink,
+    DEFAULT_BATCH_SIZE,
 )
-
 
 class TargetIceberg(Target):
     """Sample target for Iceberg."""
@@ -80,6 +80,13 @@ class TargetIceberg(Target):
             "scope",
             th.StringType,
             description="OAuth2 scope",
+            required=False,
+        ),
+        th.Property(
+            "batch_size",
+            th.IntegerType,
+            default=DEFAULT_BATCH_SIZE,
+            description="Maximum size of batches",
             required=False,
         ),
     ).to_dict()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -22,6 +22,7 @@ from singer_sdk.testing.templates import TargetFileTestTemplate
 from singer_sdk.testing.suites import SingerTestSuite
 
 from target_iceberg.target import TargetIceberg
+from target_iceberg.sinks import IcebergSink
 from target_iceberg.catalog import get_catalog_config
 import uuid
 import pytest
@@ -230,3 +231,18 @@ class TestTargetIceberg(StandardTargetTests):  # type: ignore[misc, valid-type]
                 table_creation_config["partition_spec"] = partition_spec
 
             catalog.create_table(**table_creation_config)
+
+
+def test_batch_size_configuration():
+    config = SAMPLE_CONFIG.copy()
+    config["batch_size"] = 42
+    target = TargetIceberg(config=config)
+
+    sink = IcebergSink(
+        target=target,
+        stream_name="test_stream",
+        schema={"type": "object", "properties": {}},
+        key_properties=[]
+    )
+
+    assert sink.batch_max_size == 42


### PR DESCRIPTION
- Added `batch_size` property to `meltano.yml` for configuration.
- Updated `IcebergSink` to use a default batch size and read from the configuration.
- Defined `DEFAULT_BATCH_SIZE` in `sinks.py` for better maintainability.